### PR TITLE
Added Qtum support in EVMC

### DIFF
--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -299,6 +299,9 @@ enum evmc_status_code
     /** The caller does not have enough funds for value transfer. */
     EVMC_INSUFFICIENT_BALANCE = 17,
 
+    /** Qtum specific: create with value is not allowed. */
+    EVMC_CREATE_WITH_VALUE = 1000,
+
     /** EVM implementation generic internal error. */
     EVMC_INTERNAL_ERROR = -1,
 

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -250,6 +250,8 @@ static inline const char* evmc_status_code_to_string(enum evmc_status_code statu
         return "wasm trap";
     case EVMC_INSUFFICIENT_BALANCE:
         return "insufficient balance";
+    case EVMC_CREATE_WITH_VALUE:
+        return "create with value";
     case EVMC_INTERNAL_ERROR:
         return "internal error";
     case EVMC_REJECTED:


### PR DESCRIPTION
A new error code called `Create With Value` is added in the virtual machine connector.